### PR TITLE
Rename HealthResponse to GetHealthResponse

### DIFF
--- a/models/llamacpp.yml
+++ b/models/llamacpp.yml
@@ -34,19 +34,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HealthResponse'
+                $ref: '#/components/schemas/GetHealthResponse'
         '500':
           description: Internal Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HealthResponse'
+                $ref: '#/components/schemas/GetHealthResponse'
         '503':
           description: No slot available.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HealthResponse'
+                $ref: '#/components/schemas/GetHealthResponse'
   /completion:
     post:
       operationId: postCompletion
@@ -66,7 +66,7 @@ paths:
                 $ref: '#/components/schemas/PostCompletionResponse'
 components:
   schemas:
-    HealthResponse:
+    GetHealthResponse:
       type: object
       properties:
         status:


### PR DESCRIPTION
**Description**

- Rename HealthResponse to GetHealthResponse

**Motivation**

- Make component names consistent

**Testing Done**

- Ran the following:
```
openapi-generator-cli validate -i C:\Users\hugot\workspace\llamacpp-openapi\models\llamacpp.yml
Validating spec (C:\Users\hugot\workspace\llamacpp-openapi\models\llamacpp.yml)
No validation issues detected.
```

**Backwards Compatibility Criteria (if any)**

- No dependencies yet