### PR TITLE
Fix system_prompt Shape

### DIFF
--- a/models/llamacpp.yml
+++ b/models/llamacpp.yml
@@ -386,6 +386,15 @@ components:
           type: string
         id:
           type: integer
+    SystemPrompt:
+      type: object
+      properties:
+        prompt:
+          type: string
+        anti_prompt:
+          type: string
+        assistant_name:
+          type: string
     Error:
       type: object
       properties:
@@ -535,8 +544,7 @@ components:
           type: boolean
           description: To cache or not to cache prompt
         system_prompt:
-          type: string
-          description: System prompt
+          $ref: "#/components/schemas/SystemPrompt"
         samplers:
           type: array
           items:
@@ -733,8 +741,7 @@ components:
           type: boolean
           description: To cache or not to cache prompt
         system_prompt:
-          type: string
-          description: System prompt
+          $ref: "#/components/schemas/SystemPrompt"
         samplers:
           type: array
           items:


### PR DESCRIPTION
**Description**

- Per API spec, instead of a string, system_prompt should be of the following:
```
{
    "system_prompt": {
        "prompt": "...",
        "anti_prompt": "User:",
        "assistant_name": "Assistant:"
    }
}
```

**Motivation**

- Fix incorrect API definition

**Testing Done**

- ``openapi-generator-cli validate``

**Backwards Compatibility Criteria (if any)**

- No dependency yet