### PR TITLE
Make PostInfillResponse a Separate Component

### DIFF
--- a/models/llamacpp.yml
+++ b/models/llamacpp.yml
@@ -177,7 +177,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostCompletionResponse'
+                $ref: '#/components/schemas/PostInfillResponse'
   /embedding:
     post:
       operationId: postEmbedding
@@ -775,6 +775,8 @@ components:
           items:
             type: string
           description: Samplers list
+    PostInfillResponse:
+      $ref: '#/components/schemas/PostCompletionResponse'
     PostEmbeddingRequest:
       type: object
       properties:


### PR DESCRIPTION
**Description**

- Make PostInfillResponse a Separate Component

**Motivation**

- Minor cleanup to avoid confusion

**Testing Done**

- ``openapi-generator-cli validate``

**Backwards Compatibility Criteria (if any)**

- No dependency yet