### PR TITLE
Enable Streaming Support for Java SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,20 @@
 hs_err_pid*
 replay_pid*
 
+# IntelliJ
+/.idea
+
 # Ignore generated Java client files
 /javasdk/src/main
 /javasdk/target
+/javasdk/docs
+/javasdk/.gitignore
+/javasdk/.travis.yml
+/javasdk/build.gradle
+/javasdk/build.sbt
+/javasdk/.openapi-generator
+/javasdk/git_push.sh
+/javasdk/gradle*
+/javasdk/.github
+/javasdk/api
+/javasdk/settings.gradle

--- a/javasdk/openapi-generators-config.yml
+++ b/javasdk/openapi-generators-config.yml
@@ -9,3 +9,4 @@ annotationLibrary: "swagger2"
 generateBuilders: true
 serializableModel: true
 serializationLibrary: "gson"
+supportStreaming: true

--- a/models/llamacpp.yml
+++ b/models/llamacpp.yml
@@ -628,6 +628,8 @@ components:
           type: boolean
         model:
           type: string
+        multimodal:
+          type: boolean
         tokens_predicted:
           type: integer
         tokens_evaluated:


### PR DESCRIPTION
**Description**

- Set supportStreaming to true for Java SDK generator
- Fix missing multimodal field in PostCompletionResponse
- Add integration tests/examples for processing streamed responses with PostCompletion and PostInfill
- Update .gitignore with autogenerated Java SDK files

**Motivation**

- Allow use of stream mode for PostCompletion and PostInfill

**Testing Done**

- See GitHub action results

**Backwards Compatibility Criteria (if any)**

- Cannot rollback once any code depends on multimodal field.